### PR TITLE
Add Material Components (chip,dialog,slider,progress)

### DIFF
--- a/material/src/main/scala/calico/material/Button.scala
+++ b/material/src/main/scala/calico/material/Button.scala
@@ -22,7 +22,10 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 opaque type Button[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
-object Button
+object Button:
+  @js.native
+  @JSImport("@material/web/button/text-button.js")
+  private[material] def use: Any = js.native
 
 opaque type FilledButton[F[_]] <: Button[F] = Button[F]
 object FilledButton:
@@ -45,3 +48,7 @@ private trait MaterialButton[F[_]](using F: Async[F]):
   lazy val mdOutlinedButton: MdTag[F, OutlinedButton[F]] =
     OutlinedButton.use
     MdTag("md-outlined-button")
+
+  lazy val mdButton: MdTag[F, Button[F]] =
+    val _ = Button.use
+    MdTag("md-button")

--- a/material/src/main/scala/calico/material/Chip.scala
+++ b/material/src/main/scala/calico/material/Chip.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.material
+
+import calico.html.Prop
+import cats.effect.kernel.Async
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+opaque type Chip[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
+
+object Chip:
+  extension [F[_]](chip: Chip[F])
+    def selected: Prop[F, Boolean, Boolean] = Prop("selected", identity)
+    def disabled: Prop[F, Boolean, Boolean] = Prop("disabled", identity)
+    def icon: Prop[F, String, String] = Prop("icon", identity)
+
+  @js.native
+  @JSImport("@material/web/chips/filter-chip.js")
+  private[material] def use: Any = js.native
+
+private trait MaterialChip[F[_]](using F: Async[F]):
+  lazy val mdChip: MdTag[F, Chip[F]] =
+    val _ = Chip.use
+    MdTag("md-filter-chip")

--- a/material/src/main/scala/calico/material/Dialog.scala
+++ b/material/src/main/scala/calico/material/Dialog.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.material
+
+import calico.html.Prop
+import cats.effect.kernel.Async
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+opaque type Dialog[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
+
+// Check that this is implemented correctly
+object Dialog:
+  extension [F[_]](dialog: Dialog[F])
+    def open: Prop[F, Boolean, Boolean] = Prop("open", identity)
+    def fullscreen: Prop[F, Boolean, Boolean] = Prop("fullscreen", identity)
+    def stacked: Prop[F, Boolean, Boolean] = Prop("stacked", identity)
+    def defaultAction: Prop[F, String, String] = Prop("default-action", identity)
+    def escapeKeyAction: Prop[F, String, String] = Prop("escape-key-action", identity)
+    def scrimClickAction: Prop[F, String, String] = Prop("scrim-click-action", identity)
+    def returnValue: Prop[F, String, String] = Prop("returnValue", identity)
+    def id: Prop[F, String, String] = Prop("id", identity) // Add this line
+
+  @js.native
+  @JSImport("@material/web/dialog/dialog.js")
+  private[material] def use: Any = js.native
+
+private trait MaterialDialog[F[_]](using F: Async[F]):
+  lazy val mdDialog: MdTag[F, Dialog[F]] =
+    val _ = Dialog.use
+    MdTag("md-dialog")

--- a/material/src/main/scala/calico/material/Material.scala
+++ b/material/src/main/scala/calico/material/Material.scala
@@ -21,4 +21,11 @@ import cats.effect.kernel.Async
 
 object io extends Material[IO]
 
-sealed class Material[F[_]](using Async[F]) extends MaterialButton[F], MaterialCheckbox[F]
+sealed class Material[F[_]](using Async[F])
+    extends MaterialButton[F]
+    with MaterialCheckbox[F]
+    with MaterialSwitch[F]
+    with MaterialDialog[F]
+    with MaterialChip[F]
+    with MaterialSlider[F]
+    with MaterialProgress[F]

--- a/material/src/main/scala/calico/material/Progress.scala
+++ b/material/src/main/scala/calico/material/Progress.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.material
+
+import calico.html.Prop
+import cats.effect.kernel.Async
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+opaque type LinearProgress[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
+
+object LinearProgress:
+  extension [F[_]](progress: LinearProgress[F])
+    def progress: Prop[F, Double, Double] = Prop("progress", identity)
+    def indeterminate: Prop[F, Boolean, Boolean] = Prop("indeterminate", identity)
+    def buffer: Prop[F, Double, Double] = Prop("buffer", identity)
+
+  @js.native
+  @JSImport("@material/web/progress/linear-progress.js")
+  private[material] def use: Any = js.native
+
+opaque type CircularProgress[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
+
+object CircularProgress:
+  extension [F[_]](progress: CircularProgress[F])
+    def progress: Prop[F, Double, Double] = Prop("progress", identity)
+    def indeterminate: Prop[F, Boolean, Boolean] = Prop("indeterminate", identity)
+
+  @js.native
+  @JSImport("@material/web/progress/circular-progress.js")
+  private[material] def use: Any = js.native
+
+private trait MaterialProgress[F[_]](using F: Async[F]):
+  lazy val mdLinearProgress: MdTag[F, LinearProgress[F]] =
+    val _ = LinearProgress.use
+    MdTag("md-linear-progress")
+
+  lazy val mdCircularProgress: MdTag[F, CircularProgress[F]] =
+    val _ = CircularProgress.use
+    MdTag("md-circular-progress")

--- a/material/src/main/scala/calico/material/Slider.scala
+++ b/material/src/main/scala/calico/material/Slider.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.material
+
+import calico.html.Prop
+import cats.effect.kernel.Async
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+opaque type Slider[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
+
+object Slider:
+  extension [F[_]](slider: Slider[F])
+    def value: Prop[F, Int, Int] = Prop("value", identity)
+    def min: Prop[F, Int, Int] = Prop("min", identity)
+    def max: Prop[F, Int, Int] = Prop("max", identity)
+    def step: Prop[F, Int, Int] = Prop("step", identity)
+    def disabled: Prop[F, Boolean, Boolean] = Prop("disabled", identity)
+    def labeled: Prop[F, Boolean, Boolean] = Prop("labeled", identity)
+
+  @js.native
+  @JSImport("@material/web/slider/slider.js")
+  private[material] def use: Any = js.native
+
+private trait MaterialSlider[F[_]](using F: Async[F]):
+  lazy val mdSlider: MdTag[F, Slider[F]] =
+    val _ = Slider.use
+    MdTag("md-slider")

--- a/material/src/main/scala/calico/material/Switch.scala
+++ b/material/src/main/scala/calico/material/Switch.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package calico.material
+
+import calico.html.Prop
+import cats.effect.kernel.Async
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+opaque type Switch[F[_]] <: fs2.dom.HtmlElement[F] = fs2.dom.HtmlElement[F]
+
+object Switch:
+  extension [F[_]](switch: Switch[F])
+    def selected: Prop[F, Boolean, Boolean] = Prop("selected", identity)
+    def icons: Prop[F, Boolean, Boolean] = Prop("icons", identity)
+    def disabled: Prop[F, Boolean, Boolean] = Prop("disabled", identity)
+
+  @js.native
+  @JSImport("@material/web/switch/switch.js")
+  private[material] def use: Any = js.native
+
+private trait MaterialSwitch[F[_]](using F: Async[F]):
+  lazy val mdSwitch: MdTag[F, Switch[F]] =
+    val _ = Switch.use
+    MdTag("md-switch")

--- a/sandbox/src/main/scala/calico/material/Demo.scala
+++ b/sandbox/src/main/scala/calico/material/Demo.scala
@@ -19,19 +19,134 @@ package material
 
 import calico.html.io.{*, given}
 import calico.material.io.{*, given}
+import fs2.concurrent.SignallingRef
+import cats.effect.IO
+import cats.effect.Resource
+import scala.scalajs.js
+import org.scalajs.dom
 
 object Demo extends IOWebApp:
-  def render = div(
-    label(
-      "Material 3",
-      mdCheckbox { cb =>
-        cb.checked := true
-      },
-    ),
-    mdOutlinedButton { b =>
-      "Back"
-    },
-    mdFilledButton { b =>
-      "Next"
-    },
-  )
+  def render =
+    Resource.eval(SignallingRef[IO].of(false)).flatMap { isDialogOpen =>
+      div(
+        // Checkbox component
+        label(
+          "Material 3",
+          mdCheckbox { cb =>
+            cb.checked := true
+          },
+        ),
+
+        // Button components
+        div(
+          mdOutlinedButton { b =>
+            "Back"
+          },
+          mdFilledButton { b =>
+            "Next"
+          },
+        ),
+
+        // Switch component
+        div(
+          label(
+            "Toggle Feature",
+            mdSwitch { s =>
+              s.selected := true
+              s.icons := true
+            },
+          ),
+        ),
+
+        // Chip components
+        div(
+          h3("Chips"),
+          mdChip { c =>
+            c.selected := false
+            "Basic"
+          },
+          mdChip { c =>
+            c.selected := true
+            "Selected"
+          },
+          mdChip { c =>
+            c.disabled := true
+            "Disabled"
+          },
+        ),
+
+        // Slider component
+        div(
+          h3("Slider"),
+          label(
+            "Adjust value:",
+            mdSlider { s =>
+              s.min := 0
+              s.max := 100
+              s.value := 40
+              s.labeled := true
+            },
+          ),
+        ),
+
+        // Progress indicators
+        div(
+          h3("Progress Indicators"),
+          // Linear progress
+          div(
+            p("Linear Progress:"),
+            mdLinearProgress { p =>
+              p.progress := 0.5 // 50% complete
+            },
+          ),
+          // Indeterminate linear progress
+          div(
+            p("Indeterminate Linear:"),
+            mdLinearProgress { p =>
+              p.indeterminate := true
+            },
+          ),
+          // Indeterminate circular progress
+          div(
+            p("Indeterminate Circular:"),
+            mdCircularProgress { p =>
+              p.indeterminate := true
+            },
+          ),
+        ),
+
+        // Dialog component
+        div(
+          h3("Dialog Example"),
+          // Button to open dialog
+          mdFilledButton { b =>
+            onClick(e =>
+              IO {
+                isDialogOpen.update(_ => true)
+              },
+            )
+            "Open Dialog"
+          },
+          // The dialog component
+          mdDialog { d =>
+            d.id := "demo-dialog"
+            d.open <-- isDialogOpen
+
+            div(
+              h2("Dialog Title"),
+              p("Dialog content goes here"),
+              div(
+                mdOutlinedButton { b =>
+                  onClick(e =>
+                    IO {
+                      isDialogOpen.update(_ => false)
+                    },
+                  )
+                  "Close"
+                },
+              ),
+            )
+          },
+        ),
+      )
+    }


### PR DESCRIPTION
# Summary
This PR extends the Calico Material library with several new Material Design components and provides a comprehensive demo showcasing how these components work together in an interactive application. The implementation follows the existing component patterns established in the project.

## New Components Added
Dialog Component: Modal dialog implementation with reactive open/close functionality
Chip Component: Filter chips with configurable states (selected, disabled)
Slider Component: Interactive sliders with customizable min/max values and labels
Progress Indicators: Both linear and circular variants with determinate and indeterminate states